### PR TITLE
Add blog post: Argot and the EF complete final part of funding agreement

### DIFF
--- a/data/blog/2026-06-29-ef-funding-final-part.mdx
+++ b/data/blog/2026-06-29-ef-funding-final-part.mdx
@@ -1,0 +1,36 @@
+---
+title: 'Argot and the Ethereum Foundation Complete Final Part of Funding Agreement'
+date: '2026-06-29'
+draft: false
+summary: 'Argot and the Ethereum Foundation have finalized the remaining two years of their original funding commitment, placing the reserved funds in a multi-sig with a governance structure and an independent Fail-Safe Committee.'
+layout: PostSimple
+tags: ['argot']
+---
+
+Argot is an independent collective that builds and maintains critical infrastructure for Ethereum applications, with a primary focus on Solidity. The contracts that underpin DeFi, staking infrastructure, and the core protocol itself are overwhelmingly compiled by solc. Therefore, ensuring the long-term maintenance, security, and evolution of Solidity is foundational to the economic security of the network. Beyond Solidity, Argot includes teams working on formal verification through act and hevm, developer tooling through Sourcify and ethdebug, and language research through Fe and Core Solidity, all aimed at raising the standard for verifiable, secure smart contract development.
+
+Since our formation last year, we have continued to ship Solidity releases, maintain the compiler infrastructure that the ecosystem depends on, and dedicate resources to the research and tooling that will shape Ethereum's developer experience going forward. Our [roadmap updates](https://www.argot.org/blog/2025-roadmap-update) provide a [detailed account](https://www.argot.org/blog/2026-01-15-argot-roadmap-update-2026-1) of this work.
+
+## The Original Funding Commitment
+
+When we introduced the Argot Collective in October 2024, we simultaneously announced a funding commitment from the Ethereum Foundation. That commitment was specified last year as five years of operational runway (at an ETH price of USD 2,592), with the mandate to develop and maintain critical Ethereum infrastructure under a neutral and independent umbrella. This agreement gives the collective a head start to work towards diversified funding sources and sustainably secure its work.
+
+The first three years of that commitment have already been paid out in full last year (see [here](https://www.argot.org/blog/ef-grant-announcement)). The original agreement included a plan for the next two years to be placed in a multi-sig once the relevant terms and operational setup was finalized. Today, we can confirm that this is complete, together with a governance structure designed to uphold the trust placed in us.
+
+## What This Means in Practice
+
+Approximately 4,938 stETH will be transferred into two contracts controlled and owned by a 2-of-3 multi-signature wallet, with unlock dates set for 1 July 2026 and 1 July 2027. The reserved funds are held in a 2-of-3 multi-sig controlled by the Ethereum Foundation, Argot, and a newly established Fail-Safe Committee (FSC). The FSC serves as a neutral third party: a sounding board by default and, if necessary, a mediator. The committee comprises five independent members ([Richard Meissner](https://github.com/rmeissner), [Hadrien Croubois](https://github.com/amxx), [Lev Livnev](https://github.com/livnev), [Yannis Smaragdakis](https://github.com/yanniss), [Adam Fuller](https://github.com/azf20)), one Argot member ([dxo](https://github.com/d-xo)) and one EF member ([lightclient](https://github.com/lightclient)).
+
+On the first unlock date, 50% of the total holdings will become available for Argot to claim. The remainder will unlock on the second date. This phased approach reflects both the EF's original commitment and a shared interest in responsible stewardship of resources.
+
+The default action is payout, with terms focused on the continued maintenance of Solidity and Argot's contribution to the broader Ethereum ecosystem. If materially violated, any signing party could propose changes to the unlock schedule and a 2-3 threshold could approve those changes. The Fail-Safe Committee serves as an independent arbiter in case of dispute, a safeguard for Argot's independence, and a source of domain expertise on languages and compilers.
+
+## Looking Forward
+
+We are, without question, fortunate to have secured this level of support back in 2024. But the EF's treasury is finite, and Ethereum needs to mobilize more stakeholders to contribute to public goods infrastructure. This is true not only for the projects within Argot but for the ecosystem as a whole.
+
+Ethereum underpins businesses, careers, livelihoods, and a vision of digital sovereignty that extends far beyond any single organization. The infrastructure that makes all of this possible cannot depend on a single funder indefinitely. Now is the moment for everyone who depends on Ethereum to recognize that sustaining its foundations is a shared responsibility.
+
+Argot will continue to publish transparency reports and roadmap updates every six months, as we committed to from the start. The first of these is forthcoming and will detail how we have allocated resources to date.
+
+We are grateful to the Ethereum Foundation for honoring their commitment, to the members of the Fail-Safe Committee for their willingness to serve, and to the community for holding us accountable.

--- a/data/blog/2026-06-30-ef-funding-final-part.mdx
+++ b/data/blog/2026-06-30-ef-funding-final-part.mdx
@@ -19,13 +19,13 @@ The first three years of that commitment have already been paid out in full last
 
 ## What This Means in Practice
 
-Approximately 4,938 stETH will be transferred into two contracts controlled and owned by a 2-of-3 multi-signature wallet, with unlock dates set for 1 July 2026 and 1 July 2027. The reserved funds are held in a 2-of-3 multi-sig controlled by the Ethereum Foundation, Argot, and a newly established Fail-Safe Committee (FSC). The FSC serves as a neutral third party: a sounding board by default and, if necessary, a mediator. The committee comprises five independent members ([Richard Meissner](https://github.com/rmeissner), [Hadrien Croubois](https://github.com/amxx), [Lev Livnev](https://github.com/livnev), [Yannis Smaragdakis](https://github.com/yanniss), [Adam Fuller](https://github.com/azf20)), one Argot member ([dxo](https://github.com/d-xo)) and one EF member ([lightclient](https://github.com/lightclient)).
+Approximately 4,938 stETH will be transferred into two contracts controlled and owned by a 2-of-3 multi-signature wallet, with unlock dates set for 1 July 2026 and 1 July 2027. The reserved funds are held in a 2-of-3 multi-sig controlled by Argot, a newly established Fail-Safe Committee (FSC), and the Ethereum Foundation. The FSC serves as a neutral third party: a sounding board by default and, if necessary, a mediator. The committee comprises five independent members ([Richard Meissner](https://github.com/rmeissner), [Hadrien Croubois](https://github.com/amxx), [Lev Livnev](https://github.com/livnev), [Yannis Smaragdakis](https://github.com/yanniss), [Adam Fuller](https://github.com/azf20)), one Argot member ([dxo](https://github.com/d-xo)) and one EF member ([lightclient](https://github.com/lightclient)).
 
 On the first unlock date, 50% of the total holdings will become available for Argot to claim. The remainder will unlock on the second date. This phased approach reflects both the EF's original commitment and a shared interest in responsible stewardship of resources.
 
 The default action is payout, with terms focused on the continued maintenance of Solidity and Argot's contribution to the broader Ethereum ecosystem. If materially violated, any signing party could propose changes to the unlock schedule and a 2-3 threshold could approve those changes. The Fail-Safe Committee serves as an independent arbiter in case of dispute, a safeguard for Argot's independence, and a source of domain expertise on languages and compilers.
 
-## Looking Forward
+## Looking Ahead
 
 We are, without question, fortunate to have secured this level of support back in 2024. But the EF's treasury is finite, and Ethereum needs to mobilize more stakeholders to contribute to public goods infrastructure. This is true not only for the projects within Argot but for the ecosystem as a whole.
 

--- a/data/blog/2026-06-30-ef-funding-final-part.mdx
+++ b/data/blog/2026-06-30-ef-funding-final-part.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Argot and the Ethereum Foundation Complete Final Part of Funding Agreement'
-date: '2026-06-29'
+date: '2026-06-30'
 draft: false
 summary: 'Argot and the Ethereum Foundation have finalized the remaining two years of their original funding commitment, placing the reserved funds in a multi-sig with a governance structure and an independent Fail-Safe Committee.'
 layout: PostSimple


### PR DESCRIPTION
Adds a new blog post announcing the completion of the final part of the Ethereum Foundation funding agreement.

- New post at `data/blog/2026-06-29-ef-funding-final-part.mdx`
- `draft: false`, `layout: PostSimple`, tagged `argot` — consistent with the related [EF grant announcement](https://www.argot.org/blog/ef-grant-announcement) post
- Will be published on the site when merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)