### PR TITLE
Add holders.vote to social media footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -30,6 +30,11 @@ const Footer = () => {
               <SocialIcon kind="farcaster" href={siteMetadata.farcaster} size={5} />
               <SocialIcon kind="x" href={siteMetadata.x} size={5} />
               <SocialIcon kind="bluesky" href={siteMetadata.bluesky} size={5} />
+              <SocialIcon
+                kind="holders"
+                href="https://holders.vote/h/argot.curated.hns"
+                size={5}
+              />
               <SocialIcon kind="rss" href="/feed.xml" size={5} />
             </div>
           </div>

--- a/components/social-icons/icons.tsx
+++ b/components/social-icons/icons.tsx
@@ -111,6 +111,15 @@ export function Bluesky(svgProps: SVGProps<SVGSVGElement>) {
   )
 }
 
+export function Holders(svgProps: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...svgProps}>
+      <title>Holders</title>
+      <path d="M12 3 22 21 H2 Z" />
+    </svg>
+  )
+}
+
 export function Rss(svgProps: SVGProps<SVGSVGElement>) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...svgProps}>

--- a/components/social-icons/index.tsx
+++ b/components/social-icons/index.tsx
@@ -11,6 +11,7 @@ import {
   Instagram,
   Farcaster,
   Bluesky,
+  Holders,
   Rss,
 } from './icons'
 
@@ -27,6 +28,7 @@ const components = {
   instagram: Instagram,
   farcaster: Farcaster,
   bluesky: Bluesky,
+  holders: Holders,
   rss: Rss,
 }
 


### PR DESCRIPTION
It looks like this when it's running:

<img width="1435" height="106" alt="image" src="https://github.com/user-attachments/assets/5279f44c-805e-45f2-9131-ab506df79d37" />

I'm sending an email to your public inbox to explain more.  